### PR TITLE
fix: strip interior control characters in sanitizeLabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project are documented in this file.
 
 - Add a package export `default` condition so CJS-style resolvers can find the ESM entrypoint.
   (`#8`, thanks `@grimmjoww`)
+- Strip control characters from OSC progress labels so labels cannot break emitted progress sequences. (`#15`, thanks `@devYRPauli`)
 
 ## 0.2.0 - 2025-12-25
 

--- a/src/oscProgress.ts
+++ b/src/oscProgress.ts
@@ -125,7 +125,15 @@ export function sanitizeLabel(label: string): string {
   const withoutTerminators = withoutEscape
     .replaceAll(OSC_PROGRESS_BEL, "")
     .replaceAll(OSC_PROGRESS_C1_ST, "");
-  return withoutTerminators.replaceAll("]", "").trim();
+  // Strip remaining C0 controls and DEL; a bare newline/CR/tab inside the
+  // payload would otherwise terminate or garble the surrounding OSC sequence.
+  const withoutControls = [...withoutTerminators]
+    .filter((ch) => {
+      const code = ch.codePointAt(0) ?? 0;
+      return code > 0x1f && code !== 0x7f;
+    })
+    .join("");
+  return withoutControls.replaceAll("]", "").trim();
 }
 
 /**

--- a/tests/oscProgress.test.ts
+++ b/tests/oscProgress.test.ts
@@ -20,7 +20,11 @@ describe("sanitizeLabel", () => {
   });
 
   test("strips interior control characters that would break the OSC sequence", () => {
-    expect(sanitizeLabel("a\nb\rc\td")).toBe("abcd");
+    const c0Controls = Array.from({ length: 0x20 }, (_, code) => String.fromCodePoint(code)).join(
+      "",
+    );
+
+    expect(sanitizeLabel(`a${c0Controls}\u007fb`)).toBe("ab");
     expect(sanitizeLabel("download\nrm -rf")).toBe("downloadrm -rf");
     expect(sanitizeLabel("plain label")).toBe("plain label");
   });

--- a/tests/oscProgress.test.ts
+++ b/tests/oscProgress.test.ts
@@ -18,6 +18,12 @@ describe("sanitizeLabel", () => {
     const label = `Load\u001b[31m  file${OSC_PROGRESS_ST}${OSC_PROGRESS_BEL}${OSC_PROGRESS_C1_ST}]`;
     expect(sanitizeLabel(label)).toBe("Load[31m  file");
   });
+
+  test("strips interior control characters that would break the OSC sequence", () => {
+    expect(sanitizeLabel("a\nb\rc\td")).toBe("abcd");
+    expect(sanitizeLabel("download\nrm -rf")).toBe("downloadrm -rf");
+    expect(sanitizeLabel("plain label")).toBe("plain label");
+  });
 });
 
 describe("supportsOscProgress", () => {


### PR DESCRIPTION
## What

`sanitizeLabel` is documented as producing a label that "can't break the surrounding OSC sequence", but it only removes the ESC/BEL/C1 ST/ST terminators and trims outer whitespace. Bare C0 control characters inside the label (newline, carriage return, tab, and the rest of `0x00`–`0x1F`, plus DEL `0x7F`) pass through untouched.

A control character in the OSC 9;4 payload terminates or garbles the surrounding sequence, so the trailing payload text ends up dumped on the terminal as literal output. Example via the controller:

```
setPercent("download\nrm -rf", 50)
// emits: ESC ]9;4;1;50;download\nrm -rf ESC \
//                                ^ bare newline inside the OSC payload
```

## Fix

After the existing terminator removals, drop any remaining C0 control character and DEL. Printable content, including interior spaces, is unchanged:

```ts
const withoutControls = [...withoutTerminators]
  .filter((ch) => {
    const code = ch.codePointAt(0) ?? 0;
    return code > 0x1f && code !== 0x7f;
  })
  .join("");
```

(I used a codepoint filter rather than a regex so it doesn't trip `oxlint`'s `no-control-regex` rule.)

## Tests

Added a regression case in the `sanitizeLabel` describe block:

```ts
expect(sanitizeLabel("a\nb\rc\td")).toBe("abcd");
expect(sanitizeLabel("download\nrm -rf")).toBe("downloadrm -rf");
expect(sanitizeLabel("plain label")).toBe("plain label");
```

It fails before the change (interior `\n`/`\r`/`\t` survive) and passes after. The existing terminator/whitespace test still passes, and interior spaces are preserved. `pnpm check` is green (lint, typecheck, coverage thresholds).

Found and fixed with the help of the Claude CLI.


## Real behavior proof

Running the real `sanitizeLabel` and a real `createOscProgressController` emit, before and after this change (output copied from a local `node` run against the built `dist/`):

```
label = "download\nrm -rf"

BEFORE (main)
  sanitizeLabel output: "download\nrm -rf"
  emitted OSC seq     : "]9;4;1;50;download\nrm -rf\\"
  payload has raw \n  : true        <- bare newline inside the OSC payload

AFTER (this PR)
  sanitizeLabel output: "downloadrm -rf"
  emitted OSC seq     : "]9;4;1;50;downloadrm -rf\\"
  payload has raw \n  : false
```

Before the change the newline survives into the emitted OSC 9;4 sequence, which terminates/garbles it on a real terminal and leaks the trailing payload. After the change the control character is stripped and the sequence stays intact. Interior spaces are still preserved.
