### PR TITLE
Harden OSC progress lifecycle and maintenance config

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,8 @@ This repo uses Node.js `>= 24` and `pnpm` (see `package.json`).
 ## Coding Style & Naming Conventions
 
 - TypeScript, ESM (`"type": "module"`). Keep imports explicit and Node-friendly.
-- Formatting/linting: Biome (`biome.jsonc`).
-  - 2-space indent, 100 columns, single quotes, semicolons as-needed.
+- Formatting/linting: Oxfmt (`.oxfmtrc.json`) + Oxlint.
+  - 2-space indent, 100 columns, semicolons as-needed.
 - Public API discipline: export new API from `src/index.ts`; add TSDoc for anything user-facing.
 - Naming: functions/vars `camelCase`, types `PascalCase`, constants `SCREAMING_SNAKE_CASE`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 ## 0.3.2 - Unreleased
 
+### Fixed
+
+- Match default TTY detection to the default stderr writer and make indeterminate stop calls idempotent.
+- Cancel delayed completion clears when a controller starts new progress and clamp `NaN` percentages to a valid frame.
+- Strip all C0, C1, and DEL control bytes from labels while preserving printable punctuation.
+
 ## 0.3.1 - 2026-06-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Starts a best-effort progress indicator and returns `stop(): void`.
 Notes:
 
 - `label` is appended as extra payload; **not part of the canonical OSC 9;4 spec** (many terminals ignore it, some show it).
+- default output and TTY detection both use stderr.
 - default is a timer-driven `0% → 99%` progression (never completes by itself).
 - `terminator` defaults to `st` (`ESC \\`); `bel` is also supported.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -45,10 +45,13 @@ Rule: every release = **npm publish + git tag + GitHub release** (always do all 
   - `git push origin v<version>`
 - [ ] Create GitHub release for tag `v<version>`:
   - title = `<version>` (just the version)
-  - body = changelog bullets for that version
-  - `gh release create v<version> --title "<version>" --notes "<paste bullets>"`
+  - write the changelog bullets and release proof to `/tmp/osc-progress-release.md`, then inspect it
+  - `gh release create v<version> --title "<version>" --notes-file /tmp/osc-progress-release.md`
 
 ## 6) Verify (post)
 
-- [ ] `npm view osc-progress time --json`
-- [ ] `gh release view v<version>`
+- [ ] `npm view osc-progress@<version> version dist-tags dist.tarball dist.integrity time --json`
+- [ ] Confirm `latest`, tarball, integrity, and publish time all match the published version.
+- [ ] Confirm GitHub tag + Release exist and point to the published commit.
+- [ ] Confirm the Release body contains the changelog notes plus links to the npm version page, registry tarball, integrity, and CI/proof.
+- [ ] Open the next patch section as `Unreleased`, commit, and push the release closeout.

--- a/package.json
+++ b/package.json
@@ -67,10 +67,5 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@10.33.2",
-  "pnpm": {
-    "overrides": {
-      "esbuild": "0.28.1"
-    }
-  }
+  "packageManager": "pnpm@10.33.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+overrides:
+  esbuild: 0.28.1

--- a/src/oscProgress.ts
+++ b/src/oscProgress.ts
@@ -46,7 +46,7 @@ export interface OscProgressOptions extends OscProgressSupportOptions {
   write?: (data: string) => void;
   /** Environment lookup (defaults to `process.env`). */
   env?: NodeJS.ProcessEnv;
-  /** TTY flag (defaults to `process.stdout.isTTY`). */
+  /** TTY flag (defaults to `process.stderr.isTTY`, matching the default writer). */
   isTty?: boolean;
   /** When true, emit an indeterminate progress indicator (no percentage). */
   indeterminate?: boolean;
@@ -121,19 +121,15 @@ export type OscProgressReporter = OscProgressController & {
  */
 export function sanitizeLabel(label: string): string {
   const withoutSt = label.replaceAll(OSC_PROGRESS_ST, "");
-  const withoutEscape = withoutSt.split("\u001b").join("");
-  const withoutTerminators = withoutEscape
-    .replaceAll(OSC_PROGRESS_BEL, "")
-    .replaceAll(OSC_PROGRESS_C1_ST, "");
-  // Strip remaining C0 controls and DEL; a bare newline/CR/tab inside the
-  // payload would otherwise terminate or garble the surrounding OSC sequence.
-  const withoutControls = [...withoutTerminators]
+  // Strip C0/C1 controls and DEL. This removes every OSC introducer/terminator
+  // while preserving printable payload characters such as closing brackets.
+  const withoutControls = [...withoutSt]
     .filter((ch) => {
       const code = ch.codePointAt(0) ?? 0;
-      return code > 0x1f && code !== 0x7f;
+      return code > 0x1f && code !== 0x7f && !(code >= 0x80 && code <= 0x9f);
     })
     .join("");
-  return withoutControls.replaceAll("]", "").trim();
+  return withoutControls.trim();
 }
 
 /**
@@ -149,7 +145,7 @@ export function sanitizeLabel(label: string): string {
  */
 export function supportsOscProgress(
   env: NodeJS.ProcessEnv = process.env,
-  isTty: boolean = process.stdout.isTTY,
+  isTty: boolean = process.stderr.isTTY,
   options: OscProgressSupportOptions = {},
 ): boolean {
   if (!isTty) return false;
@@ -286,6 +282,7 @@ export function startOscProgress(options: OscProgressOptions = {}): () => void {
 
   const cleanLabel = sanitizeLabel(label);
   const end = resolveTerminator(terminator);
+  let stopped = false;
 
   const send = (st: number, percent: number | null): void => {
     if (percent == null) {
@@ -299,6 +296,8 @@ export function startOscProgress(options: OscProgressOptions = {}): () => void {
   if (indeterminate) {
     send(3, null);
     return () => {
+      if (stopped) return;
+      stopped = true;
       send(0, 0);
     };
   }
@@ -314,7 +313,6 @@ export function startOscProgress(options: OscProgressOptions = {}): () => void {
   }, 900);
   timer.unref?.();
 
-  let stopped = false;
   return () => {
     if (stopped) return;
     stopped = true;
@@ -371,8 +369,10 @@ export function createOscProgressController(
     return `${baseLabel} (stalled)`;
   };
 
-  const normalizePercent = (percent: number): number =>
-    Math.max(0, Math.min(100, Math.round(percent)));
+  const normalizePercent = (percent: number): number => {
+    if (Number.isNaN(percent)) return 0;
+    return Math.max(0, Math.min(100, Math.round(percent)));
+  };
 
   let lastEmittedLabel = label;
   let lastEmittedPercent: number | null = null;
@@ -388,6 +388,13 @@ export function createOscProgressController(
   let clearTimer: NodeJS.Timeout | null = null;
   let stallEnabled = true;
 
+  const cancelPendingClear = (): boolean => {
+    if (clearTimer === null) return false;
+    clearTimeout(clearTimer);
+    clearTimer = null;
+    return true;
+  };
+
   const clearStallTimer = () => {
     if (stallTimer !== null) {
       clearTimeout(stallTimer);
@@ -397,10 +404,7 @@ export function createOscProgressController(
 
   const clearTimers = () => {
     clearStallTimer();
-    if (clearTimer !== null) {
-      clearTimeout(clearTimer);
-      clearTimer = null;
-    }
+    cancelPendingClear();
   };
 
   const scheduleStall = () => {
@@ -473,19 +477,22 @@ export function createOscProgressController(
   };
 
   const setIndeterminate = (nextLabel: string) => {
+    const resumed = cancelPendingClear();
     stallEnabled = true;
     updateSeen(nextLabel, "indeterminate", null);
-    send(3, null, nextLabel);
+    send(3, null, nextLabel, resumed);
   };
 
   const setPercent = (nextLabel: string, percent: number) => {
+    const resumed = cancelPendingClear();
     const normalized = normalizePercent(percent);
     stallEnabled = true;
     updateSeen(nextLabel, "determinate", normalized);
-    send(1, normalized, nextLabel);
+    send(1, normalized, nextLabel, resumed);
   };
 
   const setPaused = (nextLabel: string) => {
+    cancelPendingClear();
     stallEnabled = false;
     const percent = lastSeenMode === "determinate" ? lastSeenPercent : null;
     updateSeen(

--- a/tests/oscProgress.test.ts
+++ b/tests/oscProgress.test.ts
@@ -16,15 +16,18 @@ import {
 describe("sanitizeLabel", () => {
   test("removes escape and OSC terminators", () => {
     const label = `Load\u001b[31m  file${OSC_PROGRESS_ST}${OSC_PROGRESS_BEL}${OSC_PROGRESS_C1_ST}]`;
-    expect(sanitizeLabel(label)).toBe("Load[31m  file");
+    expect(sanitizeLabel(label)).toBe("Load[31m  file]");
   });
 
-  test("strips interior control characters that would break the OSC sequence", () => {
+  test("strips C0, C1, and DEL controls that would break the OSC sequence", () => {
     const c0Controls = Array.from({ length: 0x20 }, (_, code) => String.fromCodePoint(code)).join(
       "",
     );
+    const c1Controls = Array.from({ length: 0x20 }, (_, index) =>
+      String.fromCodePoint(0x80 + index),
+    ).join("");
 
-    expect(sanitizeLabel(`a${c0Controls}\u007fb`)).toBe("ab");
+    expect(sanitizeLabel(`a${c0Controls}\u007f${c1Controls}b[ok]`)).toBe("ab[ok]");
     expect(sanitizeLabel("download\nrm -rf")).toBe("downloadrm -rf");
     expect(sanitizeLabel("plain label")).toBe("plain label");
   });
@@ -33,6 +36,25 @@ describe("sanitizeLabel", () => {
 describe("supportsOscProgress", () => {
   test("requires a TTY", () => {
     expect(supportsOscProgress({ TERM_PROGRAM: "ghostty" }, false)).toBe(false);
+  });
+
+  test("defaults to the stderr TTY state", () => {
+    const stdoutDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+    const stderrDescriptor = Object.getOwnPropertyDescriptor(process.stderr, "isTTY");
+    try {
+      Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: false });
+      Object.defineProperty(process.stderr, "isTTY", { configurable: true, value: true });
+      expect(supportsOscProgress({ TERM_PROGRAM: "ghostty" })).toBe(true);
+
+      Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+      Object.defineProperty(process.stderr, "isTTY", { configurable: true, value: false });
+      expect(supportsOscProgress({ TERM_PROGRAM: "ghostty" })).toBe(false);
+    } finally {
+      if (stdoutDescriptor) Object.defineProperty(process.stdout, "isTTY", stdoutDescriptor);
+      else Reflect.deleteProperty(process.stdout, "isTTY");
+      if (stderrDescriptor) Object.defineProperty(process.stderr, "isTTY", stderrDescriptor);
+      else Reflect.deleteProperty(process.stderr, "isTTY");
+    }
   });
 
   test("returns false for unknown terminals", () => {
@@ -202,6 +224,25 @@ describe("startOscProgress", () => {
     expect(writes.at(-1)).toBe(`${OSC_PROGRESS_PREFIX}0;0;Fetch${OSC_PROGRESS_ST}`);
   });
 
+  test("indeterminate stop is idempotent", () => {
+    const writes: string[] = [];
+    const stop = startOscProgress({
+      label: "Waiting",
+      indeterminate: true,
+      write: (chunk) => writes.push(chunk),
+      env: { TERM_PROGRAM: "ghostty" },
+      isTty: true,
+    });
+
+    stop();
+    stop();
+
+    expect(writes).toEqual([
+      `${OSC_PROGRESS_PREFIX}3;;Waiting${OSC_PROGRESS_ST}`,
+      `${OSC_PROGRESS_PREFIX}0;0;Waiting${OSC_PROGRESS_ST}`,
+    ]);
+  });
+
   test("uses default write (process.stderr.write) when not provided", () => {
     const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     try {
@@ -287,11 +328,20 @@ describe("createOscProgressController", () => {
     osc.setPercent("Downloading", -10);
     vi.advanceTimersByTime(200);
     osc.setPercent("Downloading", 9000);
+    vi.advanceTimersByTime(200);
+    osc.setPercent("Downloading", Number.NaN);
+    vi.advanceTimersByTime(200);
+    osc.setPercent("Downloading", Number.POSITIVE_INFINITY);
+    vi.advanceTimersByTime(200);
+    osc.setPercent("Downloading", Number.NEGATIVE_INFINITY);
 
     expect(writes[0]).toBe(`${OSC_PROGRESS_PREFIX}1;12;Downloading${OSC_PROGRESS_ST}`);
     expect(writes[1]).toBe(`${OSC_PROGRESS_PREFIX}1;13;Downloading${OSC_PROGRESS_ST}`);
     expect(writes[2]).toBe(`${OSC_PROGRESS_PREFIX}1;0;Downloading${OSC_PROGRESS_ST}`);
     expect(writes[3]).toBe(`${OSC_PROGRESS_PREFIX}1;100;Downloading${OSC_PROGRESS_ST}`);
+    expect(writes[4]).toBe(`${OSC_PROGRESS_PREFIX}1;0;Downloading${OSC_PROGRESS_ST}`);
+    expect(writes[5]).toBe(`${OSC_PROGRESS_PREFIX}1;100;Downloading${OSC_PROGRESS_ST}`);
+    expect(writes[6]).toBe(`${OSC_PROGRESS_PREFIX}1;0;Downloading${OSC_PROGRESS_ST}`);
     vi.useRealTimers();
   });
 
@@ -305,7 +355,7 @@ describe("createOscProgressController", () => {
 
     osc.setIndeterminate(`Load\u001b[31m file${OSC_PROGRESS_ST}${OSC_PROGRESS_BEL}]`);
 
-    expect(writes[0]).toBe(`${OSC_PROGRESS_PREFIX}3;;Load[31m file${OSC_PROGRESS_ST}`);
+    expect(writes[0]).toBe(`${OSC_PROGRESS_PREFIX}3;;Load[31m file]${OSC_PROGRESS_ST}`);
   });
 
   test("supports BEL terminator", () => {
@@ -434,6 +484,29 @@ describe("createOscProgressController", () => {
 
     vi.advanceTimersByTime(200);
     expect(writes[2]).toBe(`${OSC_PROGRESS_PREFIX}0;0;Downloading${OSC_PROGRESS_ST}`);
+    vi.useRealTimers();
+  });
+
+  test("new progress cancels a pending completion clear", () => {
+    vi.useFakeTimers();
+    const writes: string[] = [];
+    const osc = createOscProgressController({
+      env: { TERM_PROGRAM: "wezterm" },
+      isTty: true,
+      clearDelayMs: 200,
+      write: (data) => writes.push(data),
+    });
+
+    osc.setPercent("Downloading", 42);
+    osc.done();
+    osc.setPercent("Downloading", 1);
+    vi.advanceTimersByTime(200);
+
+    expect(writes).toEqual([
+      `${OSC_PROGRESS_PREFIX}1;42;Downloading${OSC_PROGRESS_ST}`,
+      `${OSC_PROGRESS_PREFIX}1;100;Downloading${OSC_PROGRESS_ST}`,
+      `${OSC_PROGRESS_PREFIX}1;1;Downloading${OSC_PROGRESS_ST}`,
+    ]);
     vi.useRealTimers();
   });
 


### PR DESCRIPTION
## Summary

- align default TTY detection with the default stderr writer
- cancel stale delayed clears when a controller is reused, make indeterminate stops idempotent, and keep percent frames valid for `NaN`
- strip all C0/C1/DEL controls from labels while preserving printable punctuation
- move the esbuild security override to `pnpm-workspace.yaml`, its supported pnpm configuration location
- pin formatter defaults and strengthen release-proof/closeout documentation

## Risk

Low. Runtime changes are bounded to progress-frame emission and controller lifecycle. No API additions, package version bump, tag, or release.

## Verification

- `pnpm check` — 52 tests; 100% statements/functions/lines, 97.82% branches
- `pnpm audit --json` — 0 vulnerabilities across 147 development dependencies; package has 0 runtime dependencies
- packed-tarball black-box contract — import succeeds; stderr TTY routing, controller reuse, idempotent stop, C0/C1 sanitization, printable brackets, and non-finite percentages pass
- `npm pack` — expected 10-file package artifact
- Codex autoreview (`gpt-5.5`) — clean; no accepted/actionable findings

## Dependency audit note

The existing `esbuild@0.28.1` override remains intact for GHSA-g7r4-m6w7-qqqr. `@types/node@26.1.0` was intentionally not adopted because it was published only hours before this audit; weekly Dependabot remains enabled.
