### PR TITLE
build(deps): bump PostCSS to 8.5.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@vitest/coverage-v8": "^4.1.10",
     "oxfmt": "^0.58.0",
     "oxlint": "^1.73.0",
-    "postcss": "^8.5.16",
+    "postcss": "^8.5.17",
     "typescript": "^7.0.2",
     "vite": "^8.1.4",
     "vitest": "^4.1.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^1.73.0
         version: 1.73.0
       postcss:
-        specifier: ^8.5.16
-        version: 8.5.16
+        specifier: ^8.5.17
+        version: 8.5.17
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -798,8 +798,8 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.17:
+    resolution: {integrity: sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==}
     engines: {node: ^10 || ^12 || >=14}
 
   rolldown@1.1.5:
@@ -1466,7 +1466,7 @@ snapshots:
 
   picomatch@4.0.5: {}
 
-  postcss@8.5.16:
+  postcss@8.5.17:
     dependencies:
       nanoid: 3.3.15
       picocolors: 1.1.1
@@ -1552,7 +1552,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.16
+      postcss: 8.5.17
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
## Summary

- bump the direct PostCSS development dependency from 8.5.16 to 8.5.17
- refresh the lockfile resolution and integrity metadata

## Why

PostCSS 8.5.17 is the current stable release and includes fixes for prototype hijacking in `fromJSON()`, a stack-overflow failure, and an origin-position edge case. The direct pin also supplies the deduplicated PostCSS instance used by Vite and Vitest.

Upstream: https://github.com/postcss/postcss/blob/8.5.17/CHANGELOG.md

## Impact

Build and test tooling only; no runtime dependency or public API behavior changes.

## Proof

Exact head: `44c387179f4c14ad32285eab7fc1d27a81bba651`

- `pnpm install --frozen-lockfile`
- `pnpm check` — 52 tests passed; 100% statements/lines/functions and 97.82% branch coverage
- `pnpm audit --json` — zero vulnerabilities
- `pnpm outdated --format json` — no outdated dependencies
- packed tarball consumer import, OSC frame emission, completion/clear, and sanitization passed
- structured autoreview — clean, no accepted/actionable findings
- Public Model Identifier Gate — PASS; no model-bearing content in the diff, tests, metadata, workflows, or packed artifact
