### PR TITLE
docs: rewrite README to house standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,131 +1,107 @@
-# ⏳ osc-progress — Tiny lib for OSC 9;4 terminal progress.
+# osc-progress ⏳ — Tiny progress, right in the tab.
 
-Tiny TypeScript helper for **OSC 9;4** terminal progress (Ghostty / WezTerm / Windows Terminal).
+[![CI](https://img.shields.io/github/actions/workflow/status/steipete/osc-progress/ci.yml?branch=main&style=flat-square&label=ci)](https://github.com/steipete/osc-progress/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/osc-progress?style=flat-square)](https://www.npmjs.com/package/osc-progress)
+[![Node](https://img.shields.io/node/v/osc-progress?style=flat-square)](https://nodejs.org)
+[![License](https://img.shields.io/github/license/steipete/osc-progress?style=flat-square)](LICENSE)
+
+`osc-progress` is a TypeScript library for emitting and removing OSC 9;4 terminal progress
+sequences. It is intended for Node.js CLIs running in Ghostty, WezTerm, or Windows Terminal and
+becomes a no-op outside supported TTYs.
 
 ## Install
 
-```bash
+```sh
 pnpm add osc-progress
 ```
 
-## Usage
+Node.js 24 or newer is required.
+
+## Quick start
 
 ```ts
-import process from "node:process";
+import { setTimeout as delay } from "node:timers/promises";
 import { startOscProgress } from "osc-progress";
 
-const stop = startOscProgress({
-  label: "Fetching",
-  write: (chunk) => process.stderr.write(chunk),
-  env: process.env,
-  isTty: process.stderr.isTTY,
+const stop = startOscProgress({ label: "Indexing", indeterminate: true });
+try {
+  await delay(1_000);
+} finally {
+  stop();
+}
+```
+
+`startOscProgress()` writes to stderr by default. In a supported terminal it starts progress and
+returns an idempotent function that clears it; elsewhere both operations do nothing.
+
+## Report real progress
+
+Use a controller when the work already exposes a percentage or moves between states:
+
+```ts
+import { createOscProgressController } from "osc-progress";
+
+const progress = createOscProgressController({ stallAfterMs: 10_000 });
+progress.setIndeterminate("Connecting");
+progress.setPercent("Downloading", 42);
+progress.done();
+```
+
+Updates are deduplicated and throttled to about one every 150 ms. Percentages are rounded and
+clamped to `0..100`; `done()` and `fail()` emit their final state before clearing it.
+
+## Detection and overrides
+
+Progress is enabled only for a TTY recognized as Ghostty, WezTerm, or Windows Terminal. The same
+detection applies to both `startOscProgress()` and `createOscProgressController()`.
+
+```ts
+import { supportsOscProgress } from "osc-progress";
+
+const supported = supportsOscProgress(process.env, process.stderr.isTTY === true, {
+  forceEnvVar: "MY_CLI_FORCE_PROGRESS",
+  disableEnvVar: "MY_CLI_NO_PROGRESS",
 });
-
-// ...do work...
-
-stop();
 ```
 
-Indeterminate (spinner-like) mode:
+The named environment variables take effect when their value is `"1"`. Direct `force` and
+`disabled` options are also available; a non-TTY stream always remains disabled.
 
-```ts
-import { startOscProgress } from "osc-progress";
+## Clean stored output
 
-const stop = startOscProgress({ label: "Waiting", indeterminate: true });
-// ...
-stop();
-```
-
-Strip OSC progress from stored logs:
+Remove progress control sequences before saving captured terminal output:
 
 ```ts
 import { sanitizeOscProgress } from "osc-progress";
 
-const clean = sanitizeOscProgress(text, /*keepOsc*/ process.stdout.isTTY);
+function prepareForStorage(output: string): string {
+  return sanitizeOscProgress(output, process.stdout.isTTY === true);
+}
 ```
 
-## API
+The parser recognizes sequences terminated by `BEL`, `ST` (`ESC \\`), or C1 `ST` (`0x9c`).
 
-### `supportsOscProgress(env?, isTty?, options?)`
+## API and terminal behavior
 
-Returns `true` when emitting OSC 9;4 progress makes sense.
+The public API includes the timer-based helper, a stateful controller, support detection, label
+sanitization, sequence discovery, and stripping helpers. See the [API reference](docs/API.md) for
+signatures, options, exported constants, and OSC 9;4 portability notes.
 
-Heuristics:
+OSC 9;4 state `4` is interpreted as paused by some terminals and warning by others. The library
+emits the numeric state without trying to normalize that terminal-specific behavior. Labels are
+an extra payload outside the canonical OSC 9;4 fields, so terminals may ignore them.
 
-- requires a TTY
-- enables for `TERM_PROGRAM=ghostty*`, `TERM_PROGRAM=wezterm*`, or `WT_SESSION` (Windows Terminal)
+## Development
 
-Optional overrides:
-
-- `options.disabled` / `options.force`
-- `options.disableEnvVar` / `options.forceEnvVar` (expects `= "1"`)
-
-### `startOscProgress(options?)`
-
-Starts a best-effort progress indicator and returns `stop(): void`.
-
-Notes:
-
-- `label` is appended as extra payload; **not part of the canonical OSC 9;4 spec** (many terminals ignore it, some show it).
-- default output and TTY detection both use stderr.
-- default is a timer-driven `0% → 99%` progression (never completes by itself).
-- `terminator` defaults to `st` (`ESC \\`); `bel` is also supported.
-
-### `createOscProgressController(options?)`
-
-Returns a small stateful controller:
-
-- `setIndeterminate(label)`
-- `setPercent(label, percent)`
-- `setPaused(label)` (state `4`)
-- `done(label?)` (emit 100% then clear)
-- `fail(label?)` (emit error state then clear)
-- `clear()`
-- `dispose()` (cleanup timers/listeners)
-
-Use this when you already have real progress (bytes/total, seconds/total) and want determinate terminal progress instead of the timer-based ramp.
-
-Notes:
-
-- returns no-op methods when `supportsOscProgress(...)` is false
-- `percent` is rounded and clamped to `0..100`
-- `clear()` uses the last label (or the initial `options.label` if nothing was set yet)
-- progress updates are throttled by default (deduped + max ~1 update/150ms)
-- `stallAfterMs` emits a paused/stalled state when updates stop
-- `clearDelayMs` controls how long `done()` / `fail()` wait before clearing
-- `autoClearOnExit` clears on process exit
-
-```ts
-import process from "node:process";
-import { createOscProgressController } from "osc-progress";
-
-const osc = createOscProgressController({
-  env: process.env,
-  isTty: process.stderr.isTTY,
-  write: (chunk) => process.stderr.write(chunk),
-  stallAfterMs: 10_000,
-  clearDelayMs: 200,
-  autoClearOnExit: true,
-});
-
-osc.setIndeterminate("Connecting");
-osc.setPercent("Downloading", 12);
-osc.setPercent("Downloading", 67);
-osc.done();
+```sh
+pnpm install
+pnpm build
+pnpm test
+pnpm check
 ```
 
-#### Controller options
+`pnpm check` runs formatting, linting, typechecking, tests, and coverage thresholds.
 
-- `stallAfterMs`: emit state=4 when no updates are seen within this window.
-- `stalledLabel`: override stalled label (string or formatter).
-- `clearDelayMs`: delay before `done()`/`fail()` clears.
-- `autoClearOnExit`: clear progress on process exit.
+## License
 
-### `sanitizeOscProgress(text, keepOsc)`
-
-Removes OSC 9;4 progress sequences (terminated by `BEL`, `ST` (`ESC \\`), or `0x9c`).
-
-## Semantics / portability
-
-OSC 9;4 is widely implemented, but state `4` is ambiguous across terminals (some treat it as `paused`, some as `warning`).
-This library exposes the raw numeric state and does not try to reinterpret it.
+MIT. See [LICENSE](LICENSE).

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,124 @@
+# API reference
+
+`osc-progress` exports its public API from the package root. Progress output defaults to stderr,
+and support detection defaults to `process.env` and `process.stderr.isTTY`.
+
+## `supportsOscProgress(env?, isTty?, options?)`
+
+Returns whether emitting OSC 9;4 progress is appropriate. Detection requires a TTY and recognizes:
+
+- `TERM_PROGRAM` containing `ghostty` or `wezterm`, case-insensitively
+- `WT_SESSION`, used by Windows Terminal
+
+`options` accepts:
+
+| Option          | Behavior                                                                                    |
+| --------------- | ------------------------------------------------------------------------------------------- |
+| `disabled`      | Disables progress.                                                                          |
+| `force`         | Enables progress for an otherwise unknown terminal. It does not bypass the TTY requirement. |
+| `disableEnvVar` | Names an environment variable that disables progress when set to `"1"`.                     |
+| `forceEnvVar`   | Names an environment variable that enables progress when set to `"1"`.                      |
+
+`disabled` takes precedence over `force`. The disable environment variable takes precedence over
+the force environment variable.
+
+## `startOscProgress(options?)`
+
+Starts a best-effort progress indicator and returns an idempotent `stop(): void` function. When
+support detection fails, the returned function is a no-op.
+
+By default, the helper emits a timer-driven `0%` to `99%` progression and never completes by
+itself. Calling `stop()` clears the indicator. Set `indeterminate: true` for state `3` without a
+percentage.
+
+| Option                         | Default                | Behavior                                                                      |
+| ------------------------------ | ---------------------- | ----------------------------------------------------------------------------- |
+| `label`                        | `"Working…"`           | Extra payload appended to the sequence after control bytes are removed.       |
+| `targetMs`                     | 10 minutes             | Target duration for the internal `0%` to `99%` ramp; the minimum is 1 second. |
+| `write`                        | `process.stderr.write` | Receives each complete OSC sequence.                                          |
+| `env`                          | `process.env`          | Environment used for support detection.                                       |
+| `isTty`                        | `process.stderr.isTTY` | TTY state used for support detection.                                         |
+| `indeterminate`                | `false`                | Emits state `3` without a percentage.                                         |
+| `state`                        | `1`                    | Numeric state for determinate updates: `1`, `2`, or `4`.                      |
+| `terminator`                   | `"st"`                 | Sequence terminator: `"st"` (`ESC \\`) or `"bel"`.                            |
+| `disabled`, `force`            | `false`                | Direct support-detection overrides.                                           |
+| `disableEnvVar`, `forceEnvVar` | —                      | Environment-variable names used for detection overrides.                      |
+
+## `createOscProgressController(options?)`
+
+Creates a stateful `OscProgressReporter`. It returns the same method shape with no-op methods when
+support detection fails.
+
+| Method                       | Behavior                                                            |
+| ---------------------------- | ------------------------------------------------------------------- |
+| `setIndeterminate(label)`    | Emits state `3` without a percentage.                               |
+| `setPercent(label, percent)` | Emits state `1`; the percentage is rounded and clamped to `0..100`. |
+| `setPaused(label)`           | Emits state `4`, retaining the current percentage when determinate. |
+| `done(label?)`               | Emits `100%`, then clears after the configured delay.               |
+| `fail(label?)`               | Emits state `2`, then clears after the configured delay.            |
+| `clear()`                    | Emits state `0` with the most recently supplied label.              |
+| `dispose()`                  | Cancels timers and removes the optional process-exit listener.      |
+
+The controller accepts all `startOscProgress()` options plus:
+
+| Option            | Default                | Behavior                                                                         |
+| ----------------- | ---------------------- | -------------------------------------------------------------------------------- |
+| `stallAfterMs`    | `0`                    | Emits state `4` after this many milliseconds without an update; `0` disables it. |
+| `stalledLabel`    | `label + " (stalled)"` | Static label or formatter used for a stalled update.                             |
+| `clearDelayMs`    | `150`                  | Delay before `done()` or `fail()` clears; `0` clears immediately.                |
+| `autoClearOnExit` | `false`                | Clears progress during the Node.js `exit` event.                                 |
+
+Controller updates are deduplicated and percentage-only changes are throttled to at most about one
+update every 150 ms. A state or label change emits immediately.
+
+## Sequence and label helpers
+
+### `sanitizeLabel(label)`
+
+Removes C0 and C1 control bytes, `DEL`, escape bytes, and OSC terminators, then trims surrounding
+whitespace. Emitters apply this automatically to labels.
+
+### `findOscProgressSequences(text)`
+
+Returns an array of `{ start, end, raw, terminator }` records for complete OSC 9;4 sequences.
+`terminator` is `"st"`, `"bel"`, or `"c1st"`. Unterminated sequences are ignored.
+
+### `stripOscProgress(text)`
+
+Removes OSC 9;4 sequences terminated by `ST`, `BEL`, or C1 `ST`. An unterminated sequence is
+removed from its prefix through the end of the string.
+
+### `sanitizeOscProgress(text, keepOsc)`
+
+Returns `text` unchanged when `keepOsc` is `true`; otherwise, returns `stripOscProgress(text)`.
+
+## Constants and types
+
+The package exports the protocol constants `OSC_PROGRESS_PREFIX`, `OSC_PROGRESS_ST`,
+`OSC_PROGRESS_BEL`, and `OSC_PROGRESS_C1_ST`.
+
+It also exports these TypeScript types:
+
+- `OscProgressController`
+- `OscProgressReporter`
+- `OscProgressControllerOptions`
+- `OscProgressOptions`
+- `OscProgressSequence`
+- `OscProgressSupportOptions`
+- `OscProgressTerminator`
+
+## OSC 9;4 semantics
+
+The emitted numeric states are:
+
+| State | Meaning                                       |
+| ----- | --------------------------------------------- |
+| `0`   | Clear or hide progress.                       |
+| `1`   | Normal determinate progress.                  |
+| `2`   | Error.                                        |
+| `3`   | Indeterminate progress.                       |
+| `4`   | Paused or warning, depending on the terminal. |
+
+Labels are appended as an extra payload. They are not part of the canonical OSC 9;4 fields, so
+some terminals display them and others ignore them. The library exposes state `4` as-is because
+terminals do not agree on its interpretation.


### PR DESCRIPTION
## Summary

Rewrites the README around the smallest npm install and a runnable 60-second example, then adds progressive sections for real progress, detection, stored-output cleanup, development, and licensing. The README shrinks from 131 to 107 lines.

## Moved or dropped

- Moves the detailed API, controller options, helper behavior, exported types/constants, and OSC 9;4 portability notes into `docs/API.md`.
- Drops the old broad claim that OSC 9;4 is “widely implemented” because the repository does not establish that claim; specific detected terminals remain documented from source.
- Leaves `CHANGELOG.md` unchanged because it has no precedent for documentation-only entries.

## Verification

- `pnpm install --frozen-lockfile`, `pnpm build`, `pnpm test`, and `pnpm check` pass (52 tests; 100% statements/lines/functions and 97.82% branches).
- All four README TypeScript samples compile with the repository toolchain. The quick start and controller samples also run under a pseudo-TTY and emit the expected OSC start/update/completion/clear frames.
- A clean temporary project successfully runs `pnpm add osc-progress` and imports the published package; `npm view osc-progress` reports `0.3.2` with Node `>=24`.
- Every relative link resolves. Every external URL returns HTTP 200 except the expected npmjs.com automated-client 403; all four badge SVGs render without `invalid` or `not found` content.
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local` reports no accepted/actionable findings.
