### PR TITLE
fix: recognize Canario OSC progress support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## 0.3.3 - Unreleased
 
+### Fixed
+
+- Recognize Canario as supporting OSC 9;4 progress. (`#33`, thanks `@hugows`)
+
 ## 0.3.2 - 2026-07-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![License](https://img.shields.io/github/license/steipete/osc-progress?style=flat-square)](LICENSE)
 
 `osc-progress` is a TypeScript library for emitting and removing OSC 9;4 terminal progress
-sequences. It is intended for Node.js CLIs running in Ghostty, WezTerm, or Windows Terminal and
-becomes a no-op outside supported TTYs.
+sequences. It is intended for Node.js CLIs running in Ghostty, WezTerm, Canario, or Windows
+Terminal and becomes a no-op outside supported TTYs.
 
 ## Install
 
@@ -52,7 +52,7 @@ clamped to `0..100`; `done()` and `fail()` emit their final state before clearin
 
 ## Detection and overrides
 
-Progress is enabled only for a TTY recognized as Ghostty, WezTerm, or Windows Terminal. The same
+Progress is enabled only for a TTY recognized as Ghostty, WezTerm, Canario, or Windows Terminal. The same
 detection applies to both `startOscProgress()` and `createOscProgressController()`.
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ clamped to `0..100`; `done()` and `fail()` emit their final state before clearin
 
 ## Detection and overrides
 
-Progress is enabled only for a TTY recognized as Ghostty, WezTerm, Canario, or Windows Terminal. The same
-detection applies to both `startOscProgress()` and `createOscProgressController()`.
+Progress is enabled only for a TTY recognized as Ghostty, WezTerm, Canario, or Windows Terminal.
+The same detection applies to both `startOscProgress()` and `createOscProgressController()`.
 
 ```ts
 import { supportsOscProgress } from "osc-progress";

--- a/docs/API.md
+++ b/docs/API.md
@@ -7,7 +7,7 @@ and support detection defaults to `process.env` and `process.stderr.isTTY`.
 
 Returns whether emitting OSC 9;4 progress is appropriate. Detection requires a TTY and recognizes:
 
-- `TERM_PROGRAM` containing `ghostty` or `wezterm`, case-insensitively
+- `TERM_PROGRAM` containing `ghostty`, `wezterm`, or `canario`, case-insensitively
 - `WT_SESSION`, used by Windows Terminal
 
 `options` accepts:

--- a/src/oscProgress.ts
+++ b/src/oscProgress.ts
@@ -137,7 +137,8 @@ export function sanitizeLabel(label: string): string {
  *
  * Default heuristics:
  * - requires `isTty === true`
- * - enables for Ghostty (`TERM_PROGRAM=ghostty*`), WezTerm (`TERM_PROGRAM=wezterm*`), Canario (`TERM_PROGRAM=canario*`), Windows Terminal (`WT_SESSION`)
+ * - enables for Ghostty (`TERM_PROGRAM=ghostty*`), WezTerm (`TERM_PROGRAM=wezterm*`),
+ *   Canario (`TERM_PROGRAM=canario*`), or Windows Terminal (`WT_SESSION`)
  *
  * Override knobs:
  * - `options.force` / `options.disabled`

--- a/src/oscProgress.ts
+++ b/src/oscProgress.ts
@@ -137,7 +137,7 @@ export function sanitizeLabel(label: string): string {
  *
  * Default heuristics:
  * - requires `isTty === true`
- * - enables for Ghostty (`TERM_PROGRAM=ghostty*`), WezTerm (`TERM_PROGRAM=wezterm*`), Windows Terminal (`WT_SESSION`)
+ * - enables for Ghostty (`TERM_PROGRAM=ghostty*`), WezTerm (`TERM_PROGRAM=wezterm*`), Canario (`TERM_PROGRAM=canario*`), Windows Terminal (`WT_SESSION`)
  *
  * Override knobs:
  * - `options.force` / `options.disabled`
@@ -162,6 +162,7 @@ export function supportsOscProgress(
   const termProgram = (env.TERM_PROGRAM ?? "").toLowerCase();
   if (termProgram.includes("ghostty")) return true;
   if (termProgram.includes("wezterm")) return true;
+  if (termProgram.includes("canario")) return true;
   if (env.WT_SESSION) return true;
   return false;
 }

--- a/tests/oscProgress.test.ts
+++ b/tests/oscProgress.test.ts
@@ -61,9 +61,10 @@ describe("supportsOscProgress", () => {
     expect(supportsOscProgress({ TERM_PROGRAM: "unknown" }, true)).toBe(false);
   });
 
-  test("supports Ghostty/WezTerm/Windows Terminal", () => {
+  test("supports known OSC 9;4 terminals", () => {
     expect(supportsOscProgress({ TERM_PROGRAM: "ghostty" }, true)).toBe(true);
     expect(supportsOscProgress({ TERM_PROGRAM: "WezTerm" }, true)).toBe(true);
+    expect(supportsOscProgress({ TERM_PROGRAM: "Canario" }, true)).toBe(true);
     expect(supportsOscProgress({ WT_SESSION: "1" }, true)).toBe(true);
   });
 


### PR DESCRIPTION
## Why

Canario supports OSC 9;4 progress, but `supportsOscProgress` treats it as an unknown terminal because it reports `TERM_PROGRAM=canario`. This causes progress output to be silently disabled in a real TTY.

## What changed

- Recognize `TERM_PROGRAM` values containing `canario`
- Add a regression test
- Update README and API documentation

## Verification

- `pnpm check` passes
- 52 tests passing
- Commit authored and committed as Hugo Schmitt <hugows@gmail.com>