### PR TITLE
chore(deps): refresh source map codec lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ packages:
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/sourcemap-codec@1.5.5':
-    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+  '@jridgewell/sourcemap-codec@1.6.0':
+    resolution: {integrity: sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==}
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
@@ -947,12 +947,12 @@ snapshots:
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
-  '@jridgewell/sourcemap-codec@1.5.5': {}
+  '@jridgewell/sourcemap-codec@1.6.0': {}
 
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/sourcemap-codec': 1.6.0
 
   '@oxc-project/types@0.147.0': {}
 
@@ -1346,7 +1346,7 @@ snapshots:
 
   magic-string@0.30.21:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/sourcemap-codec': 1.6.0
 
   magicast@0.5.4:
     dependencies:


### PR DESCRIPTION
Refresh the development dependency lockfile with `pnpm update --latest`. This updates the source-map codec used by the development tools; no library source or public API changes are needed.

Dependency diff: `@jridgewell/sourcemap-codec` **1.5.5 → 1.6.0**, including its consumers in `@jridgewell/trace-mapping` and `magic-string`. All eight direct development dependencies, pnpm 11.24.0, and the esbuild 0.28.2 override already match their latest stable registry versions. No major upgrades were available or skipped. No dependencies were added or removed. The lockfile was regenerated by pnpm.

The existing Actions references already resolve to their latest releases: `actions/checkout@v7` = v7.0.1, `actions/setup-node@v7` = v7.0.0, and `pnpm/action-setup@v6` = v6.0.10. No workflow edits are necessary.

### Validation and CI reasoning

Default-branch build/test CI was already green: https://github.com/steipete/osc-progress/actions/runs/33145289912. The `ci` workflow runs the frozen install and complete checks on Node 24. The separate Dependabot update runs are dependency automation, not build/test proof; there are no scheduled production or monitoring workflows in this repository.

The PR build/test CI passed on commit `a0c3b70`: https://github.com/steipete/osc-progress/actions/runs/33380655750 (`test (24): success`). GitGuardian Security Checks also passed. Default-branch CI remains green; this PR has not been merged.

Validated locally with Node v24.20.0 and pnpm 11.24.0:

```sh
PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm install --frozen-lockfile
PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm check
pnpm outdated --format json
git diff --check
```

Real output excerpts:

```text
Already up to date
Done in 309ms using pnpm v11.24.0
All matched files use the correct format.
Test Files  2 passed (2)
     Tests  52 passed (52)
Statements   : 100% ( 246/246 )
Branches     : 97.85% ( 137/140 )
Functions    : 100% ( 43/43 )
Lines        : 100% ( 223/223 )
{}
```

### Live integration proof

Imported the actually built package through its public package export, hashed the real README, and used the default stderr writer in a real pseudo-terminal with Ghostty detection. The consumer asserts the indeterminate → completion → clear sequence and validates stripping the captured progress frames.

```sh
PATH="/opt/homebrew/opt/node@24/bin:$PATH"
set -o pipefail
script -q /dev/null env TERM_PROGRAM=ghostty node --input-type=module -e '
import assert from "node:assert/strict";
import { createReadStream } from "node:fs";
import { createHash } from "node:crypto";
import { setTimeout as delay } from "node:timers/promises";
import { createOscProgressController } from "osc-progress";
assert.equal(process.stderr.isTTY, true);
const progress = createOscProgressController();
progress.setIndeterminate("Hashing README.md");
const hash = createHash("sha256");
let bytes = 0;
for await (const chunk of createReadStream("README.md")) {
  bytes += chunk.length;
  hash.update(chunk);
}
progress.done("Hashed README.md");
await delay(200);
progress.dispose();
console.log("README.md: " + bytes + " bytes; SHA-256=" + hash.digest("hex"));
console.log("stderr TTY=" + process.stderr.isTTY);
' | node --input-type=module -e '
import assert from "node:assert/strict";
import { findOscProgressSequences, stripOscProgress } from "osc-progress";
let output = "";
for await (const chunk of process.stdin) output += chunk;
const frames = findOscProgressSequences(output);
assert.deepEqual(frames.map(frame => frame.raw.slice(6).split(";")[0]), ["3", "1", "0"]);
const clean = stripOscProgress(output);
assert.ok(clean.includes("stderr TTY=true"));
assert.ok(!clean.includes("\u001b"));
console.log(clean.trim());
console.log("PASS: built package emitted indeterminate, 100%, and clear frames through a real TTY; captured output sanitized.");
'
```

Real output excerpts:

```text
README.md: 3635 bytes; SHA-256=257d7457dfd3d380acc64054cd2530f8a540483120c7de7a306a3fd4fa6176f2
stderr TTY=true
PASS: built package emitted indeterminate, 100%, and clear frames through a real TTY; captured output sanitized.
```

The macOS `script` utility also emitted an EOF echo before the first output line; the excerpt above omits that terminal bookkeeping. The actual progress frames were parsed and asserted before sanitization.

Codex autoreview completed with `scoped-clean`: no accepted or actionable findings at the requested default P0 priority.

No changelog entry is needed for this internal development dependency refresh. This PR is for orchestrator review and landing; it is not a release.
